### PR TITLE
パーツ選択UIとレスポンシブ動作のバグ修正

### DIFF
--- a/v2/asset/css/narrow.css
+++ b/v2/asset/css/narrow.css
@@ -167,3 +167,7 @@ main {
 .tail-select .select-label {
   padding-right: 16px;
 }
+
+.tab-content.results .shrink-toggle:checked + .shrink-label + .shrink-content {
+  height: auto;
+}

--- a/v2/asset/js/mainsdisplay.js
+++ b/v2/asset/js/mainsdisplay.js
@@ -3,6 +3,9 @@
 var calcFlg = 0;
 var resultFlg = 0;
 
+// パーツ選択UIのインスタンス
+var partsSelector;
+
 function View_Set(value1) {
 	var writeValue = "";
 	writeValue += "<a name='link" + value1 + "'></a><table class='cstable'><tr><td>" + nameView[value1];
@@ -527,6 +530,8 @@ function Preset_Set(value1) {
 			Type_Slot_Set(value1, i - 1);
 		}
 	}
+	
+	Select_Reload();
 }
 
 function Lv_Set(value1) {
@@ -607,8 +612,12 @@ function Set_Storage(category, key, value) {
 	localStorage.setItem("simulator", JSON.stringify(container));
 }
 
+// パーツ選択UIの初期化
 function Select_Set() {
-	tail.select("select.parts", {
+	if (partsSelector) {
+		partsSelector.remove();
+	}
+	partsSelector = tail.select("select.parts", {
 		animate: false,
 		openAbove: false,
 		width: "100%",
@@ -616,4 +625,9 @@ function Select_Set() {
 		search: true,
 		searchMinLength: 0,
 	});
+}
+
+// パーツ選択UIを再読み込み(プリセット装着時など用)
+function Select_Reload() {
+	partsSelector.reload();
 }


### PR DESCRIPTION
以下2件のバグ修正です。

- プリセット装着時にパーツ選択UIの状態が更新されないバグ
- PCレイアウトでマシン詳細を畳んだ後にウィンドウサイズを狭めてスマホレイアウトにするとマシン詳細が表示されないバグ

動作確認は↓からお願いいたします。
https://k-tkyk.github.io/autorank-4wdminigp.github.io/