### PR TITLE
「t秒後最高速度」のチャートに走行距離の近似値表示機能を追加

### DIFF
--- a/asset/js/mainscommon.js
+++ b/asset/js/mainscommon.js
@@ -202,19 +202,40 @@ function Diagnosis_Calc(resultValueKai, shindantire, shindantirekei) {
 	function calcSpeed(n) {
 		return ((1.0 + Math.exp(-1.0 * currentValue * n )) / 2.0 * speedValue * spowerValue - resultValueKai[9] / 1000.0) * 3.6;
 	}
+	//シンプソン法による走行距離導出
+	function simpson(f, t1, t2, n) {
+		var h = (t2 - t1) / (2.0 * n);
+		var s = f(t1) + f(t2);
+		for (var i = 1; i < n; i++) {
+			s = s + 4.0 * f(t1 + (2.0 * i - 1.0) * h) + 2.0 * f(t1 + 2.0 * i * h);
+		}
+		s = s + 4.0 * f(t1 + (2.0 * n - 1.0) * h);
+		s = s * (h / 3.0);
+		return s;
+	}
+	/* シンプソン法のテストコード
+	function testFunc(x) {
+		return Math.pow(x, 2) + 3;
+	}
+	console.log(simpson(testFunc, 1, 2, 10), 16/3);*/
+
 	//10秒後最高速
 	diagnosis[diagnosisValue[30]] = calcSpeed(10.0);
 	//20秒後最高速
 	diagnosis[diagnosisValue[31]] = calcSpeed(20.0);
 	//n秒後最高速
-	var time = [];
-	var speed = [];
-	for (var i = 0; i <= 60; i+=5) {
+	var step = 1;
+	var max = 60;
+	var time = [0];
+	var current = [[calcSpeed(0), 0]];
+	var distance = 0;
+	for (var i = step; i <= max; i+=step) {
 		time.push(i);
-		speed.push(calcSpeed(i));
+		distance += simpson(calcSpeed, i - step, i, 10) / 3.6;
+		current.push([calcSpeed(i), distance.toFixed(2)]);
 	}
 	chartValues.speedDecrement.time = time;
-	chartValues.speedDecrement.current = speed;
+	chartValues.speedDecrement.current = current;
 
 	//前後の重心
 	var chassisIndex = kaizouArray[3][0];

--- a/v2/asset/js/diagnosis.js
+++ b/v2/asset/js/diagnosis.js
@@ -64,11 +64,22 @@ function View_Chart() {
 				}
 			}
 		},
+		zAxis: {
+			title: {
+				text: '走行距離[m]',
+			},
+			visible: false,
+		},
 		series: [{
 			name: '現在のセット',
 		}, {
 			name: 'ロック中'
 		}],
+		plotOptions: {
+			series: {
+				keys: ['y', 'distance']
+			}
+		},
 		legend: {
 			enabled: false
 		},
@@ -79,7 +90,7 @@ function View_Chart() {
 			headerFormat: '<div class="tooltip-title">{point.key} s</div>',
 			pointFormat:'<div class="tooltip-points">' +
 			'<span class="tooltip-series-name" style="color: {series.color}">{series.name}: </span>' +
-			'<span class="tooltip-point-value">{point.y} km/h</span></div>',
+			'<span class="tooltip-point-value">{point.y} km/h ({point.distance} m)</span></div>',
 			valueDecimals: 3
 		},
 		responsive: {},
@@ -91,20 +102,22 @@ function View_Chart() {
 	});	
 }
 
+let csd = chartValues.speedDecrement;
+
 function Lock_Line() {
-	chartValues.speedDecrement.lock = chartValues.speedDecrement.current.concat();
+	csd.lock = csd.current.concat();
 	Update_Chart();
 }
 
 function Update_Chart() {
 	chart.update({
 		xAxis: {
-			categories: chartValues.speedDecrement.time
+			categories: csd.time
 		},
 		series: [{
-			data: chartValues.speedDecrement.current
+			data: csd.current
 		}, {
-			data: chartValues.speedDecrement.lock
+			data: csd.lock.speed
 		}]
 	});
 }

--- a/v2/asset/js/diagnosis.js
+++ b/v2/asset/js/diagnosis.js
@@ -21,7 +21,7 @@
 	writeValue += "<br><font color='#FFA500'>※5 誤差あり(電池消耗未実装)</font>";
 	writeValue += "<br><font color='#FFA500'>※6 情報提供感謝します</font>";
 	writeValue += "<br><font color='#FFA500'>※7 ロックを押すと表示中の線を固定して他のセットとの比較が可能です。既にロック中の線がある場合は古い方を破棄します。</font>";
-	writeValue += "<br><font color='#FFA500'>※8 ツールチップ中の括弧内数値は、初速を最高速として各時刻まで無負荷走行した距離の近似値です。</font>";
+	writeValue += "<br><font color='#FFA500'>※8 ツールチップ中の括弧内数値は、初速を最高速として各時刻まで直線を無負荷走行した距離の近似値です。</font>";
 	document.getElementById("diagnosis-main").innerHTML = writeValue;
 	View_Chart();
 }

--- a/v2/asset/js/diagnosis.js
+++ b/v2/asset/js/diagnosis.js
@@ -65,12 +65,6 @@ function View_Chart() {
 				}
 			}
 		},
-		zAxis: {
-			title: {
-				text: '走行距離[m]',
-			},
-			visible: false,
-		},
 		series: [{
 			name: '現在のセット',
 		}, {

--- a/v2/asset/js/diagnosis.js
+++ b/v2/asset/js/diagnosis.js
@@ -8,7 +8,7 @@
 		}
 		writeValue += "<td>" + diagnosisView[i] + "<input class='csinput' type='text' id='" + diagnosisValue[i] + "' value=''></td>";
 	}
-	writeValue += "</tr><tr><td colspan='4'>t秒後最高速度(仮)(時速)<font color='#FFA500'>※7</font><div id='chart'></div></td></tr></table><table class='cstable'><tr class='specs'>";
+	writeValue += "</tr><tr><td colspan='4'>t秒後最高速度(仮)(時速)<font color='#FFA500'>※7※8</font><div id='chart'></div></td></tr></table><table class='cstable'><tr class='specs'>";
 	writeValue += "<td><input class='csinput1' type='radio' id='shindantire1' name='shindantire' onchange='All_Calc()' checked>マシン診断　";
 	writeValue += "<input class='csinput1' type='radio' id='shindantire2' name='shindantire' onchange='All_Calc()'>タイヤ径差表示　";
 	writeValue += "<select id='shindantirekei' onchange='All_Calc()'>";
@@ -21,6 +21,7 @@
 	writeValue += "<br><font color='#FFA500'>※5 誤差あり(電池消耗未実装)</font>";
 	writeValue += "<br><font color='#FFA500'>※6 情報提供感謝します</font>";
 	writeValue += "<br><font color='#FFA500'>※7 ロックを押すと表示中の線を固定して他のセットとの比較が可能です。既にロック中の線がある場合は古い方を破棄します。</font>";
+	writeValue += "<br><font color='#FFA500'>※8 ツールチップ中の括弧内数値は、初速を最高速として各時刻まで無負荷走行した距離の近似値です。</font>";
 	document.getElementById("diagnosis-main").innerHTML = writeValue;
 	View_Chart();
 }

--- a/v2/asset/js/diagnosis.js
+++ b/v2/asset/js/diagnosis.js
@@ -117,7 +117,7 @@ function Update_Chart() {
 		series: [{
 			data: csd.current
 		}, {
-			data: csd.lock.speed
+			data: csd.lock
 		}]
 	});
 }


### PR DESCRIPTION
チャートのツールチップ内に「初速を最高速として各時刻まで直線を無負荷走行した距離の近似値」を表示する機能を追加しました。
また、1秒ごとにプロットするよう変更しました。

↓のテスト環境にて動作確認いただけます。
https://k-tkyk.github.io/autorank-4wdminigp.github.io/v2/